### PR TITLE
feat: rename contact page to nous-trouver / find-us

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -22,7 +22,7 @@ L'insolite en pleine nature corrézienne : dormir en yourte ou en cabane au cœu
 
 ## Conversion & proof
 
-- CTA primaire : partir réserver sur Airbnb. Yourte : https://www.airbnb.fr/rooms/965598367739509311 — **le lien de l'annonce cabane reste à retrouver** (les anciens liens courts abnb.me sont morts ; en attendant, le CTA cabane renvoie vers l'annonce de la yourte). Repli : la page contact (téléphone/email).
+- CTA primaire : partir réserver sur Airbnb. Yourte : https://www.airbnb.fr/rooms/965598367739509311 — **le lien de l'annonce cabane reste à retrouver** (les anciens liens courts abnb.me sont morts ; en attendant, le CTA cabane renvoie vers l'annonce de la yourte). Repli : la page Nous trouver (téléphone).
 - La ligne à retenir après 10 secondes : « une parenthèse insolite au cœur de la nature corrézienne ».
 - Échelle de conviction : voir le lieu (photos immersives) → se projeter dans le séjour (confort de la yourte/cabane, activités autour) → sentir l'authenticité de l'accueil → vérifier la praticité (localisation, horaires) → partir réserver en confiance.
 - Preuves en main : aucune pour l'instant ; le lien vers l'annonce Airbnb (avec ses avis) est la piste la plus proche, une fois retrouvé.

--- a/e2e/carousel.spec.ts
+++ b/e2e/carousel.spec.ts
@@ -26,7 +26,15 @@ test.describe('Carousel', () => {
       await firstImage.click({ delay: 1000 })
 
       await expect(closeFslightboxButton).toBeVisible()
-      await expect(fullscreenFslightboxButton).toBeVisible()
+
+      // fslightbox only renders the fullscreen button when the Fullscreen API
+      // is available, which is not the case on WebKit/iOS
+      const fullscreenSupported = await page.evaluate(
+        () => document.fullscreenEnabled
+      )
+      if (fullscreenSupported) {
+        await expect(fullscreenFslightboxButton).toBeVisible()
+      }
     })
 
     test('should switch image with previous and next button', async ({

--- a/e2e/header-navigation.spec.ts
+++ b/e2e/header-navigation.spec.ts
@@ -115,16 +115,16 @@ test.describe('Header navigation', () => {
       await expect(page.getByRole('heading', { name: 'Cabane', exact: true })).toBeAttached()
     })
 
-    test('should be in the contact page after clicked on Contact', async ({
+    test('should be in the find us page after clicked on Nous trouver', async ({
       page
     }) => {
-      const contactLink = page
+      const findUsLink = page
         .getByTestId('mobile-header-navbar')
-        .getByRole('link', { name: 'Contact' })
+        .getByRole('link', { name: 'Nous trouver' })
 
       await openBurgerMenu(page)
-      await contactLink.click()
-      await page.waitForURL('**/contact')
+      await findUsLink.click()
+      await page.waitForURL('**/nous-trouver')
 
       await expect(
         page.getByRole('heading', {
@@ -228,15 +228,15 @@ test.describe('Header navigation', () => {
       await expect(page.getByRole('heading', { name: 'Cabane', exact: true })).toBeVisible()
     })
 
-    test('should be in the contact page after clicked on Contact', async ({
+    test('should be in the find us page after clicked on Nous trouver', async ({
       page
     }) => {
-      const contactLink = page
+      const findUsLink = page
         .getByTestId('desktop-header-navbar')
-        .getByRole('link', { name: 'Contact' })
+        .getByRole('link', { name: 'Nous trouver' })
 
-      await contactLink.click()
-      await page.waitForURL('**/contact')
+      await findUsLink.click()
+      await page.waitForURL('**/nous-trouver')
 
       await expect(
         page.getByRole('heading', {

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -6,6 +6,12 @@ import {
 } from '../playwright.config'
 import { openBurgerMenu } from './commons'
 
+// Simulate a granted geolocation so the itinerary dialog resolves a position
+test.use({
+  geolocation: { latitude: 45.221387, longitude: 1.251147 },
+  permissions: ['geolocation']
+})
+
 test.beforeEach(async ({ page }) => {
   await page.goto(frenchURL)
 })
@@ -17,11 +23,14 @@ test.describe('Map', () => {
 
     test.beforeEach(async ({ page }) => {
       await openBurgerMenu(page)
-      await page.getByRole('link', { name: 'Contact' }).click()
-      await page.waitForURL('**/contact')
+      await page
+        .getByTestId('mobile-header-navbar')
+        .getByRole('link', { name: 'Nous trouver' })
+        .click()
+      await page.waitForURL('**/nous-trouver')
     })
 
-    test('should display the map on the contact page', async ({ page }) => {
+    test('should display the map on the find us page', async ({ page }) => {
       await expect(page.locator('.leaflet-popup-content-wrapper')).toBeVisible()
     })
 
@@ -37,12 +46,10 @@ test.describe('Map', () => {
       ).toBeVisible()
     })
 
-    test('should display the phone number on the popup', async ({ page }) => {
-      await expect(page.getByTestId('phone-number')).toBeVisible()
-    })
-
-    test('should display the email on the popup', async ({ page }) => {
-      await expect(page.getByTestId('map-address-email')).toBeVisible()
+    test('should display the exact address notice', async ({ page }) => {
+      await expect(
+        page.getByText('Adresse exacte communiquée après la réservation')
+      ).toBeVisible()
     })
   })
 
@@ -51,11 +58,14 @@ test.describe('Map', () => {
     test.use({ viewport: DESKTOP_VIEWPORT })
 
     test.beforeEach(async ({ page }) => {
-      await page.getByRole('link', { name: 'Contact' }).click()
-      await page.waitForURL('**/contact')
+      await page
+        .getByTestId('desktop-header-navbar')
+        .getByRole('link', { name: 'Nous trouver' })
+        .click()
+      await page.waitForURL('**/nous-trouver')
     })
 
-    test('should display the map on the contact page', async ({ page }) => {
+    test('should display the map on the find us page', async ({ page }) => {
       await expect(page.locator('.leaflet-popup-content-wrapper')).toBeVisible()
     })
 
@@ -71,12 +81,10 @@ test.describe('Map', () => {
       ).toBeVisible()
     })
 
-    test('should display the phone number on the popup', async ({ page }) => {
-      await expect(page.getByTestId('phone-number')).toBeVisible()
-    })
-
-    test('should display the email on the popup', async ({ page }) => {
-      await expect(page.getByTestId('map-address-email')).toBeVisible()
+    test('should display the exact address notice', async ({ page }) => {
+      await expect(
+        page.getByText('Adresse exacte communiquée après la réservation')
+      ).toBeVisible()
     })
   })
 })

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,12 @@
-import { FlatCompat } from '@eslint/eslintrc'
-import { dirname } from 'path'
-import { fileURLToPath } from 'url'
+import { defineConfig, globalIgnores } from 'eslint/config'
+import nextVitals from 'eslint-config-next/core-web-vitals'
+import nextTs from 'eslint-config-next/typescript'
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname
-})
-
-const eslintConfig = [
-  ...compat.extends('next/core-web-vitals', 'next/typescript')
-]
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  // Default ignores of eslint-config-next.
+  globalIgnores(['.next/**', 'out/**', 'build/**', 'next-env.d.ts'])
+])
 
 export default eslintConfig

--- a/messages/en.json
+++ b/messages/en.json
@@ -2,7 +2,7 @@
   "Common": {
     "home": "Home",
     "accommodations": "Accommodations",
-    "contact": "Contact",
+    "findUs": "Find us",
     "activities": "Activities",
     "loading": "Loading",
     "update": "Update",
@@ -13,7 +13,6 @@
     "description": "Description",
     "price": "Price",
     "bookOn": "Book on {platform}",
-    "seeAirbnbListings": "See our Airbnb listings",
     "yurt": "Yurt",
     "cabin": "Cabin",
     "yurtInformation": "Yurt information",
@@ -78,12 +77,15 @@
     "cabinP1": "The cabin sleeps 2 (double bed). It has a table and chairs on the terrace (but you're free to move them wherever you like!). Its double doors and two windows give the impression of being right in the middle of nature.",
     "cabinP2": "The shower, dry toilets and a small summer kitchen area are located outside."
   },
-  "Contact": {
-    "contactMainTitle": "Find Les cabanes de la Reynie",
+  "FindUs": {
+    "mainTitle": "Find Les cabanes de la Reynie",
     "location": "Our location",
     "openingHours": "Opening Hours",
+    "day": "Day",
     "opening": "Opening",
     "closing": "Closing",
+    "openingHoursUpdateSuccess": "Opening hours updated successfully",
+    "openingHoursUpdateError": "Something went wrong while updating the opening hours",
     "monday": "Monday",
     "tuesday": "Tuesday",
     "wednesday": "Wednesday",
@@ -98,6 +100,7 @@
     "geoLocationNotFound": "Geolocation not found",
     "confirmLocationDescription": "For a better user experience on our site, we need to know your location. You can activate it at the top of this page or in your browser settings.",
     "confirmLocationButton": "See itinerary",
+    "locationFoundDescription": "Your position is ready: click “See itinerary” to open the route in Google Maps.",
     "locationDescription": "Exact address communicated after booking",
     "geoLocationLoading": "Geolocation in progress...",
     "geoLocationPermissionDenied": "Geolocation denied. Please allow access to your position.",
@@ -128,7 +131,7 @@
   },
   "Admin": {
     "personnalInformation": "Personnal information",
-    "personnalInformationDescription": "The information here will be displayed on the map in the contact page"
+    "personnalInformationDescription": "The information here will be displayed on the map in the Find us page"
   },
   "Errors": {
     "genericTitle": "Something went wrong!",
@@ -144,7 +147,7 @@
     "yurt": "The yurt",
     "cabin": "The cabin",
     "activities": "Activities",
-    "contact": "Contact",
+    "findUs": "Find us",
     "allRightsReserved": "All Rights Reserved",
     "developedBy": "Developed by",
     "address": "Address"
@@ -167,9 +170,9 @@
         "description": "The cabin accommodates two people and offers, a few steps away, an outdoor shower, dry toilets and a summer kitchen area."
       }
     },
-    "contact": {
-      "title": "Contact",
-      "description": "Contact Les Cabanes de la Reynie, unusual accommodation in Corrèze. Find our opening hours, address and directions to reach our yurt and cabin."
+    "findUs": {
+      "title": "Find us",
+      "description": "Find Les Cabanes de la Reynie in Corrèze: opening hours, directions and phone number to reach our yurt and cabin."
     },
     "activity": {
       "title": "Activities",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2,7 +2,7 @@
   "Common": {
     "home": "Accueil",
     "accommodations": "Logements",
-    "contact": "Contact",
+    "findUs": "Nous trouver",
     "activities": "Activités",
     "loading": "Chargement",
     "update": "Mettre à jour",
@@ -13,7 +13,6 @@
     "description": "Description",
     "price": "Prix",
     "bookOn": "Réserver sur {platform}",
-    "seeAirbnbListings": "Voir nos annonces sur Airbnb",
     "yurt": "Yourte",
     "cabin": "Cabane",
     "yurtInformation": "Informations concernant la yourte",
@@ -78,12 +77,15 @@
     "cabinP1": "La cabane peut accueillir 2 personnes (un lit-double). Elle dispose d'une table et de chaises sur sa terrasse (mais libre à vous de les déplacer où vous le désirez !). Sa double-porte et ses deux fenêtres donnent l'impression d'être au beau milieu de la nature.",
     "cabinP2": "La douche, les toilettes sèches et un petit coin cuisine d'été se trouvent à l'extérieur."
   },
-  "Contact": {
-    "contactMainTitle": "Trouver Les cabanes de la Reynie",
-    "location": "Nous trouver",
+  "FindUs": {
+    "mainTitle": "Trouver Les cabanes de la Reynie",
+    "location": "Notre emplacement",
     "openingHours": "Les horaires",
+    "day": "Jour",
     "opening": "Ouverture",
     "closing": "Fermeture",
+    "openingHoursUpdateSuccess": "Les horaires ont bien été mis à jour",
+    "openingHoursUpdateError": "Une erreur est survenue lors de la mise à jour des horaires",
     "monday": "Lundi",
     "tuesday": "Mardi",
     "wednesday": "Mercredi",
@@ -98,6 +100,7 @@
     "geoLocationNotFound": "Localisation n'a pas été trouvée",
     "confirmLocationDescription": "Pour une meilleure expérience utilisateur sur notre site, nous avons besoin connaitre votre localisation. Vous pouvez l'activer en haut de cette page ou dans les paramètres de votre navigateur.",
     "confirmLocationButton": "Voir itinéraire",
+    "locationFoundDescription": "Votre position est prête : cliquez sur « Voir itinéraire » pour ouvrir le trajet dans Google Maps.",
     "locationDescription": "Adresse exacte communiquée après la réservation",
     "geoLocationLoading": "Localisation en cours...",
     "geoLocationPermissionDenied": "Géolocalisation refusée. Veuillez autoriser l'accès à votre position.",
@@ -128,7 +131,7 @@
   },
   "Admin": {
     "personnalInformation": "Informations personnelles",
-    "personnalInformationDescription": "Les informations ici vont être affichées sur la carte dans la page contact"
+    "personnalInformationDescription": "Les informations ici vont être affichées sur la carte dans la page Nous trouver"
   },
   "Errors": {
     "genericTitle": "Une erreur est survenue !",
@@ -144,7 +147,7 @@
     "yurt": "La yourte",
     "cabin": "La cabane",
     "activities": "Les activités",
-    "contact": "Contact",
+    "findUs": "Nous trouver",
     "allRightsReserved": "Tous droits réservés",
     "developedBy": "Développé par",
     "address": "Adresse"
@@ -167,9 +170,9 @@
         "description": "La cabane peut accueillir deux personnes et offre, à deux-pas, une douche extérieure, des toilettes sèches et un espace cuisine d'été."
       }
     },
-    "contact": {
-      "title": "Contact",
-      "description": "Contactez Les Cabanes de la Reynie, hébergement insolite en Corrèze. Retrouvez nos horaires d'ouverture, adresse et itinéraire pour rejoindre notre yourte et cabane."
+    "findUs": {
+      "title": "Nous trouver",
+      "description": "Retrouvez Les Cabanes de la Reynie en Corrèze : horaires d'ouverture, itinéraire et téléphone pour rejoindre notre yourte et notre cabane."
     },
     "activity": {
       "title": "Activités",

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,7 @@ import createNextIntlPlugin from 'next-intl/plugin'
 const nextConfig: NextConfig = {
   reactCompiler: true,
   images: {
+    formats: ['image/avif', 'image/webp'],
     qualities: [75],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384, 400],
     deviceSizes: [640, 828, 1080, 1920, 2048],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "test": "playwright test --ui",
     "test:write": "playwright codegen --viewport-size=320,900 http://localhost:3000",
     "test:run": "playwright test",

--- a/src/app/[locale]/admin/components/tabs/AdminTabs.tsx
+++ b/src/app/[locale]/admin/components/tabs/AdminTabs.tsx
@@ -7,21 +7,24 @@ import {
   TabsTrigger
 } from '@/shared/components/ui/tabs'
 import { cn } from '@/shared/utils/tailwind'
+import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 
 type AdminTabsProps = {
   homeContent: React.ReactNode
   yurtContent: React.ReactNode
   cabinContent: React.ReactNode
-  contactContent: React.ReactNode
+  findUsContent: React.ReactNode
 }
 
 export const AdminTabs = ({
   homeContent,
   yurtContent,
   cabinContent,
-  contactContent
+  findUsContent
 }: AdminTabsProps) => {
+  const tCommon = useTranslations('Common')
+
   const [activeTab, setActiveTab] = useState('home')
 
   const handleTabChange = (value: string) => {
@@ -31,10 +34,10 @@ export const AdminTabs = ({
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange} className='w-full'>
       <TabsList className='grid w-full grid-cols-4'>
-        <TabsTrigger value='home'>Accueil</TabsTrigger>
-        <TabsTrigger value='yurt'>Yourte</TabsTrigger>
-        <TabsTrigger value='cabin'>Cabane</TabsTrigger>
-        <TabsTrigger value='contact'>Contact</TabsTrigger>
+        <TabsTrigger value='home'>{tCommon('home')}</TabsTrigger>
+        <TabsTrigger value='yurt'>{tCommon('yurt')}</TabsTrigger>
+        <TabsTrigger value='cabin'>{tCommon('cabin')}</TabsTrigger>
+        <TabsTrigger value='find-us'>{tCommon('findUs')}</TabsTrigger>
       </TabsList>
 
       <TabsContent
@@ -59,10 +62,10 @@ export const AdminTabs = ({
       </TabsContent>
 
       <TabsContent
-        value='contact'
-        className={cn({ hidden: activeTab !== 'contact' })}
+        value='find-us'
+        className={cn({ hidden: activeTab !== 'find-us' })}
       >
-        {contactContent}
+        {findUsContent}
       </TabsContent>
     </Tabs>
   )

--- a/src/app/[locale]/admin/components/tabs/FindUsSection.tsx
+++ b/src/app/[locale]/admin/components/tabs/FindUsSection.tsx
@@ -2,13 +2,16 @@ import { AddressInformationSection } from '@/features/address/components/Address
 import { OpeningHoursSection } from '@/features/openingHours/components/OpeningHoursSection'
 import { Heading } from '@/shared/components/Heading'
 import { Separator } from '@/shared/components/ui/separator'
+import { useTranslations } from 'next-intl'
 import { AdminSection } from '../AdminSection'
 
-export const ContactSection = () => {
+export const FindUsSection = () => {
+  const tCommon = useTranslations('Common')
+
   return (
     <AdminSection>
       <Heading level={2} className='my-8 text-center'>
-        Contact
+        {tCommon('findUs')}
       </Heading>
 
       <AddressInformationSection />

--- a/src/app/[locale]/admin/page.tsx
+++ b/src/app/[locale]/admin/page.tsx
@@ -7,7 +7,7 @@ import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { AdminTabs } from './components/tabs/AdminTabs'
 import { CabinSection } from './components/tabs/CabinSection'
-import { ContactSection } from './components/tabs/ContactSection'
+import { FindUsSection } from './components/tabs/FindUsSection'
 import { HomeSection } from './components/tabs/HomeSection'
 import { YurtSection } from './components/tabs/YurtSection'
 
@@ -32,7 +32,7 @@ const Admin = async () => {
         homeContent={<HomeSection />}
         yurtContent={<YurtSection />}
         cabinContent={<CabinSection />}
-        contactContent={<ContactSection />}
+        findUsContent={<FindUsSection />}
       />
     </Container>
   )

--- a/src/app/[locale]/logements/cabane/page.tsx
+++ b/src/app/[locale]/logements/cabane/page.tsx
@@ -130,11 +130,7 @@ export default async function Cabin({ params }: Props) {
 
           <CabinPrice />
 
-          <BookingLinks
-            bookList={CABIN_BOOK_LIST}
-            label={tCommon('seeAirbnbListings')}
-            className='mt-10'
-          />
+          <BookingLinks bookList={CABIN_BOOK_LIST} className='mt-10' />
         </AccommodationsHeaderContent>
       </AccommodationsHeader>
 

--- a/src/app/[locale]/nous-trouver/page.tsx
+++ b/src/app/[locale]/nous-trouver/page.tsx
@@ -1,11 +1,16 @@
+import { getAddress } from '@/features/address/infrastructure/queries/getAddress'
 import { OpeningHoursSection } from '@/features/openingHours/components/OpeningHoursSection'
 import { routing } from '@/i18n/routing'
 import { ESTABLISHMENT_TITLE } from '@/shared/_constants/establishmentInformation'
 import { Container } from '@/shared/components/Container'
 import { Heading } from '@/shared/components/Heading'
+import {
+  ESTABLISHMENT_POSITION,
+  FRENCH_PHONE_CODE
+} from '@/shared/components/map/_const'
 import { MapSection } from '@/shared/components/map/MapSection'
 import { env } from '@/shared/lib/env'
-import { pageAlternates } from '@/shared/lib/seo'
+import { localizedUrl, pageAlternates } from '@/shared/lib/seo'
 import { Metadata } from 'next'
 import { hasLocale } from 'next-intl'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
@@ -20,15 +25,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const tSEO = await getTranslations({ locale, namespace: 'SEO' })
 
   return {
-    title: tSEO('contact.title'),
-    description: tSEO('contact.description'),
-    alternates: pageAlternates(locale, '/contact'),
+    title: tSEO('findUs.title'),
+    description: tSEO('findUs.description'),
+    alternates: pageAlternates(locale, '/nous-trouver'),
     openGraph: {
-      title: `${tSEO('contact.title')} - ${ESTABLISHMENT_TITLE}`,
-      description: tSEO('contact.description'),
+      title: `${tSEO('findUs.title')} - ${ESTABLISHMENT_TITLE}`,
+      description: tSEO('findUs.description'),
       type: 'website',
       locale,
-      url: `${env.NEXT_PUBLIC_BASE_URL}/${locale}/contact`,
+      url: localizedUrl(locale, '/nous-trouver'),
       siteName: ESTABLISHMENT_TITLE,
       images: [
         {
@@ -40,13 +45,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     twitter: {
       card: 'summary_large_image',
-      title: `${tSEO('contact.title')} - ${ESTABLISHMENT_TITLE}`,
-      description: tSEO('contact.description')
+      title: `${tSEO('findUs.title')} - ${ESTABLISHMENT_TITLE}`,
+      description: tSEO('findUs.description')
     }
   }
 }
 
-export default async function Contact({ params }: Props) {
+export default async function FindUs({ params }: Props) {
   const { locale } = await params
 
   if (!hasLocale(routing.locales, locale)) {
@@ -57,19 +62,28 @@ export default async function Contact({ params }: Props) {
 
   const tSEO = await getTranslations('SEO')
 
-  const t = await getTranslations('Contact')
+  const t = await getTranslations('FindUs')
+
+  const address = await getAddress()
+  const [latitude, longitude] = ESTABLISHMENT_POSITION
 
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'LocalBusiness',
     name: ESTABLISHMENT_TITLE,
-    description: tSEO('contact.description'),
+    description: tSEO('findUs.description'),
     url: env.NEXT_PUBLIC_BASE_URL,
     image: `${env.NEXT_PUBLIC_BASE_URL}/yurt.jpg`,
+    telephone: `+${FRENCH_PHONE_CODE}${address.phone.trim().slice(1)}`,
     address: {
       '@type': 'PostalAddress',
       addressRegion: 'Corrèze',
       addressCountry: 'FR'
+    },
+    geo: {
+      '@type': 'GeoCoordinates',
+      latitude,
+      longitude
     }
   }
 
@@ -80,7 +94,7 @@ export default async function Contact({ params }: Props) {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
       <Heading level={1} className='my-8'>
-        {t('contactMainTitle')}
+        {t('mainTitle')}
       </Heading>
 
       <div className='grid grid-cols-1 gap-8 lg:grid-cols-2'>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -15,7 +15,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { href: '/', priority: 1, changeFrequency: 'monthly' },
     { href: '/logements/yourte', priority: 0.8, changeFrequency: 'monthly' },
     { href: '/logements/cabane', priority: 0.8, changeFrequency: 'monthly' },
-    { href: '/contact', priority: 0.7, changeFrequency: 'yearly' },
+    { href: '/nous-trouver', priority: 0.7, changeFrequency: 'yearly' },
     { href: '/activites', priority: 0.5, changeFrequency: 'monthly' },
     { href: '/activites/1', priority: 0.5, changeFrequency: 'monthly' },
     { href: '/activites/2', priority: 0.5, changeFrequency: 'monthly' },

--- a/src/features/address/AddressSchema.ts
+++ b/src/features/address/AddressSchema.ts
@@ -12,7 +12,12 @@ export const AddressSchema = z.object({
     .refine(validator.isMobilePhone, {
       message: 'Numéro de téléphone invalide'
     }),
-  email: z.string().refine(validator.isEmail, {
-    message: 'Email invalide'
-  })
+  email: z
+    .string()
+    .refine(validator.isEmail, {
+      message: 'Email invalide'
+    })
+    .refine((value) => !value.toLowerCase().startsWith('example-'), {
+      message: "Adresse d'exemple : renseignez l'email réel de l'établissement"
+    })
 })

--- a/src/features/openingHours/components/DayRow.tsx
+++ b/src/features/openingHours/components/DayRow.tsx
@@ -5,11 +5,9 @@ import {
   FormMessage
 } from '@/shared/components/ui/form'
 import { Input } from '@/shared/components/ui/input'
+import { useTranslations } from 'next-intl'
 import { UseFormReturn } from 'react-hook-form'
-import {
-  OpeningHoursFormData,
-  OpeningHoursRowData
-} from '../_types'
+import { OpeningHoursFormData, OpeningHoursRowData } from '../_types'
 import { TableRow } from './TableRow'
 
 type DayRowProps = OpeningHoursRowData & {
@@ -26,6 +24,8 @@ export const DayRow = ({
   isEdit,
   form
 }: DayRowProps) => {
+  const tFindUs = useTranslations('FindUs')
+
   const openingDate = isEdit ? (
     <FormField
       control={form.control}
@@ -33,7 +33,12 @@ export const DayRow = ({
       render={({ field }) => (
         <FormItem>
           <FormControl>
-            <Input type='time' required {...field} />
+            <Input
+              type='time'
+              required
+              aria-label={`${dayTranslation} - ${tFindUs('opening')}`}
+              {...field}
+            />
           </FormControl>
           <FormMessage />
         </FormItem>
@@ -50,7 +55,12 @@ export const DayRow = ({
       render={({ field }) => (
         <FormItem>
           <FormControl>
-            <Input type='time' required {...field} />
+            <Input
+              type='time'
+              required
+              aria-label={`${dayTranslation} - ${tFindUs('closing')}`}
+              {...field}
+            />
           </FormControl>
           <FormMessage />
         </FormItem>
@@ -62,7 +72,10 @@ export const DayRow = ({
 
   return (
     <TableRow day={day}>
-      <th className='border border-input px-2 py-2 align-middle sm:px-4'>
+      <th
+        scope='row'
+        className='border border-input px-2 py-2 align-middle sm:px-4'
+      >
         {dayTranslation}
       </th>
       <td className='border border-input px-2 py-2 align-middle sm:px-4'>

--- a/src/features/openingHours/components/OpeningHours.tsx
+++ b/src/features/openingHours/components/OpeningHours.tsx
@@ -12,7 +12,7 @@ type OpeningHoursProps = {
 }
 
 export const OpeningHours = async ({ editable }: OpeningHoursProps) => {
-  const tContact = await getTranslations('Contact')
+  const tFindUs = await getTranslations('FindUs')
 
   const incomingOpeningHoursData = await getOpeningHours()
 
@@ -46,8 +46,8 @@ export const OpeningHours = async ({ editable }: OpeningHoursProps) => {
             <AlertCircleIcon className={cn('stroke-primary h-5 w-5')} />
           </IconContainer>
           <div>
-            <P>{tContact('departuresDescription')}</P>
-            <P className='not-first:mt-0'>{tContact('arrivalsDescription')}</P>
+            <P>{tFindUs('departuresDescription')}</P>
+            <P className='not-first:mt-0'>{tFindUs('arrivalsDescription')}</P>
           </div>
         </div>
       )}

--- a/src/features/openingHours/components/OpeningHoursForm.tsx
+++ b/src/features/openingHours/components/OpeningHoursForm.tsx
@@ -30,7 +30,7 @@ export const OpeningHoursForm = ({
   const [isPending, startTransition] = useTransition()
   const [isEdit, handleToggleEdit] = useToggle(false)
 
-  const tContact = useTranslations('Contact')
+  const tFindUs = useTranslations('FindUs')
 
   const form = useForm<OpeningHoursFormData>({
     resolver: zodResolver(OpeningHoursFormSchema),
@@ -52,7 +52,7 @@ export const OpeningHoursForm = ({
       const res = await updateOpeningHours(openingHoursData)
 
       if (res?.validationErrors) {
-        toast.error('There was an error updating price.', {
+        toast.error(tFindUs('openingHoursUpdateError'), {
           action: {
             label: t('close'),
             onClick: () => toast.dismiss()
@@ -71,7 +71,7 @@ export const OpeningHoursForm = ({
         return
       }
 
-      toast.success("Success ! Yurt's price updated", {
+      toast.success(tFindUs('openingHoursUpdateSuccess'), {
         action: {
           label: t('close'),
           onClick: () => toast.dismiss()
@@ -86,9 +86,9 @@ export const OpeningHoursForm = ({
       <form onSubmit={form.handleSubmit(onSubmit)} className='h-full w-full'>
         <table className='w-full grow'>
           <TableHeader
-            day=''
-            opening={tContact('opening')}
-            closing={tContact('closing')}
+            day={tFindUs('day')}
+            opening={tFindUs('opening')}
+            closing={tFindUs('closing')}
           />
           <tbody className='text-center'>
             {openingHoursRows.map(rowData => (

--- a/src/features/openingHours/components/OpeningHoursSection.tsx
+++ b/src/features/openingHours/components/OpeningHoursSection.tsx
@@ -7,12 +7,12 @@ type OpeningHoursSectionProps = {
 }
 
 export const OpeningHoursSection = ({ editable }: OpeningHoursSectionProps) => {
-  const tContact = useTranslations('Contact')
+  const tFindUs = useTranslations('FindUs')
 
   return (
     <section className='mb-8'>
       <Heading level={2} className='my-8'>
-        {tContact('openingHours')}
+        {tFindUs('openingHours')}
       </Heading>
 
       <OpeningHours editable={editable} />

--- a/src/features/openingHours/components/TableHeader.tsx
+++ b/src/features/openingHours/components/TableHeader.tsx
@@ -8,9 +8,15 @@ export const TableHeader = ({ day, opening, closing }: TableHeaderProps) => {
   return (
     <thead>
       <tr>
-        <th className='h-16 border border-input text-lg'>{day}</th>
-        <th className='h-16 border border-input text-lg '>{opening}</th>
-        <th className='h-16 border border-input text-lg '>{closing}</th>
+        <th scope='col' className='h-16 border border-input text-lg'>
+          {day}
+        </th>
+        <th scope='col' className='h-16 border border-input text-lg'>
+          {opening}
+        </th>
+        <th scope='col' className='h-16 border border-input text-lg'>
+          {closing}
+        </th>
       </tr>
     </thead>
   )

--- a/src/features/openingHours/hooks/useConvertToOpeningHoursRowData.tsx
+++ b/src/features/openingHours/hooks/useConvertToOpeningHoursRowData.tsx
@@ -12,7 +12,7 @@ type ConvertToOpeningHoursRowDataProps = {
 export const useConvertToOpeningHoursRowData = ({
   openingHoursFormData
 }: ConvertToOpeningHoursRowDataProps): OpeningHoursRowData[] => {
-  const t = useTranslations('Contact')
+  const t = useTranslations('FindUs')
 
   const openingHoursRowData: OpeningHoursRowData[] = [
     {

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -10,7 +10,10 @@ export const routing = defineRouting({
   localeCookie: false,
   pathnames: {
     '/': '/',
-    '/contact': '/contact',
+    '/nous-trouver': {
+      fr: '/nous-trouver',
+      en: '/find-us'
+    },
     '/logements/cabane': {
       fr: '/logements/cabane',
       en: '/accommodations/cabin'

--- a/src/shared/_constants/SEO.ts
+++ b/src/shared/_constants/SEO.ts
@@ -20,10 +20,10 @@ export const SEO = {
         "La cabane peut accueillir deux personnes et offre, à deux-pas, une douche extérieure, des toilettes sèches et un espace cuisine d'été."
     }
   },
-  contact: {
-    title: 'Contact',
+  findUs: {
+    title: 'Nous trouver',
     description:
-      "Contactez Les Cabanes de la Reynie, hébergement insolite en Corrèze. Retrouvez nos horaires d'ouverture, adresse et itinéraire pour rejoindre notre yourte et cabane."
+      "Retrouvez Les Cabanes de la Reynie en Corrèze : horaires d'ouverture, itinéraire et téléphone pour rejoindre notre yourte et notre cabane."
   },
   activity: {
     title: 'Activités',

--- a/src/shared/_constants/bookings.ts
+++ b/src/shared/_constants/bookings.ts
@@ -4,7 +4,7 @@ export const YURT_BOOK_LIST: BookEntity[] = [
   { title: 'Airbnb', href: 'https://www.airbnb.fr/rooms/965598367739509311' }
 ]
 
-// Cabin listing URL lost — points to the yurt listing until recovered
+// TODO: temporary — cabin listing URL lost, points to the yurt listing until recovered
 export const CABIN_BOOK_LIST: BookEntity[] = [
   { title: 'Airbnb', href: 'https://www.airbnb.fr/rooms/965598367739509311' }
 ]

--- a/src/shared/_constants/page.ts
+++ b/src/shared/_constants/page.ts
@@ -4,7 +4,7 @@ export const PAGE_ROUTES = {
     yurt: '/logements/yourte',
     cabin: '/logements/cabane'
   },
-  contact: '/contact',
+  findUs: '/nous-trouver',
   activity: {
     home: '/activites',
     activity1: '/activites/1',

--- a/src/shared/components/carousel/AppCarousel.tsx
+++ b/src/shared/components/carousel/AppCarousel.tsx
@@ -7,7 +7,7 @@ import {
 import { Progress } from '@/shared/components/ui/progress'
 import { useTranslations } from 'next-intl'
 import dynamic from 'next/dynamic'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { CarouselHeader } from './CarouselHeader'
 import { CarouselProps } from './_types'
 
@@ -24,22 +24,27 @@ export const AppCarousel = ({
   const t = useTranslations('Carousel')
   const [emblaApi, setEmblaApi] = useState<CarouselApi>()
   const [scrollProgress, setScrollProgress] = useState(0)
+  const [lightboxMounted, setLightboxMounted] = useState(false)
 
-  const onScroll = (emblaApi: CarouselApi) => {
-    if (emblaApi) {
-      const progress = Math.trunc(emblaApi.scrollProgress() * 100)
-
-      if (progress !== scrollProgress) {
-        setScrollProgress(progress)
-      }
-    }
+  // Mount the lightbox lazily, on the first toggle
+  if (lightboxController.toggler && !lightboxMounted) {
+    setLightboxMounted(true)
   }
+
+  const onScroll = useCallback((emblaApi: CarouselApi) => {
+    if (emblaApi) {
+      setScrollProgress(Math.trunc(emblaApi.scrollProgress() * 100))
+    }
+  }, [])
 
   useEffect(() => {
     if (!emblaApi) return
 
-    onScroll(emblaApi)
     emblaApi.on('scroll', onScroll).on('slideFocus', onScroll)
+
+    return () => {
+      emblaApi.off('scroll', onScroll).off('slideFocus', onScroll)
+    }
   }, [emblaApi, onScroll])
 
   return (
@@ -68,8 +73,9 @@ export const AppCarousel = ({
         />
       </EmblaCarousel>
 
-      {lightboxSources?.length ? (
+      {lightboxMounted && lightboxSources?.length ? (
         <FsLightbox
+          openOnMount
           toggler={lightboxController.toggler}
           slide={lightboxController.sourceIndex + 1}
           sources={lightboxSources}

--- a/src/shared/components/footer/Footer.tsx
+++ b/src/shared/components/footer/Footer.tsx
@@ -33,7 +33,7 @@ export const Footer = () => {
               </Link>
             </FooterItem>
             <FooterItem>
-              <Link href={PAGE_ROUTES.contact}>{tFooter('contact')}</Link>
+              <Link href={PAGE_ROUTES.findUs}>{tFooter('findUs')}</Link>
             </FooterItem>
           </ul>
         </FooterNav>

--- a/src/shared/components/map/CustomMaker/Itinerary.tsx
+++ b/src/shared/components/map/CustomMaker/Itinerary.tsx
@@ -6,16 +6,16 @@ import { NavigationIcon } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
 export const Itinerary = () => {
-  const tContact = useTranslations('Contact')
+  const tFindUs = useTranslations('FindUs')
 
   return (
-    <div className='flex flex-col text-primary hover:underline'>
+    <span className='flex flex-col text-primary hover:underline'>
       <span className='flex items-center'>
         <IconContainer>
           <NavigationIcon className={APP_ICON_SIZE_CLASSNAME} />
         </IconContainer>
-        {tContact('Itinerary')}
+        {tFindUs('Itinerary')}
       </span>
-    </div>
+    </span>
   )
 }

--- a/src/shared/components/map/CustomMaker/ItineraryAlertDialog.tsx
+++ b/src/shared/components/map/CustomMaker/ItineraryAlertDialog.tsx
@@ -13,79 +13,82 @@ import {
 } from '@/shared/components/ui/alert-dialog'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Itinerary } from './Itinerary'
 
 export const ItineraryAlertDialog = () => {
-  const tContact = useTranslations('Contact')
+  const tFindUs = useTranslations('FindUs')
   const tCommon = useTranslations('Common')
 
   const [userLocation, setUserLocation] = useState<number[]>([])
   const [isDialogOpen, setIsDialogOpen] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
 
-  const successFunction = (position: GeolocationPosition) => {
+  const successFunction = useCallback((position: GeolocationPosition) => {
     const { latitude, longitude } = position.coords
     setUserLocation([latitude, longitude])
     setIsLoading(false)
-  }
+  }, [])
 
-  const errorFunction = (error: GeolocationPositionError) => {
-    setIsLoading(false)
+  const errorFunction = useCallback(
+    (error: GeolocationPositionError) => {
+      setIsLoading(false)
 
-    switch (error.code) {
-      case error.PERMISSION_DENIED:
-        toast.error(tContact('geoLocationPermissionDenied'), {
-          action: {
-            label: tCommon('close'),
-            onClick: () => toast.dismiss()
-          },
-          duration: Infinity
-        })
-        break
+      switch (error.code) {
+        case error.PERMISSION_DENIED:
+          toast.error(tFindUs('geoLocationPermissionDenied'), {
+            action: {
+              label: tCommon('close'),
+              onClick: () => toast.dismiss()
+            },
+            duration: Infinity
+          })
+          break
 
-      case error.POSITION_UNAVAILABLE:
-        toast.error(tContact('geoLocationPermissionDeniedButtonDescription'), {
-          action: {
-            label: tContact('geoLocationPermissionDeniedButton'),
-            onClick: () => toast.dismiss()
-          },
-          duration: Infinity
-        })
-        break
+        case error.POSITION_UNAVAILABLE:
+          toast.error(tFindUs('geoLocationPermissionDeniedButtonDescription'), {
+            action: {
+              label: tFindUs('geoLocationPermissionDeniedButton'),
+              onClick: () => toast.dismiss()
+            },
+            duration: Infinity
+          })
+          break
 
-      case error.TIMEOUT:
-        toast.error(tContact('geoLocationPermissionDeniedButtonDescription'), {
-          action: {
-            label: tContact('geoLocationPermissionDeniedButton'),
-            onClick: () => toast.dismiss()
-          },
-          duration: Infinity
-        })
-        break
+        case error.TIMEOUT:
+          toast.error(tFindUs('geoLocationPermissionDeniedButtonDescription'), {
+            action: {
+              label: tFindUs('geoLocationPermissionDeniedButton'),
+              onClick: () => toast.dismiss()
+            },
+            duration: Infinity
+          })
+          break
 
-      default:
-        toast.error(tContact('geoLocationPermissionDeniedButtonDescription'), {
-          action: {
-            label: tCommon('close'),
-            onClick: () => toast.dismiss()
-          },
-          duration: Infinity
-        })
-    }
-  }
+        default:
+          toast.error(tFindUs('geoLocationPermissionDeniedButtonDescription'), {
+            action: {
+              label: tCommon('close'),
+              onClick: () => toast.dismiss()
+            },
+            duration: Infinity
+          })
+      }
+    },
+    [tCommon, tFindUs]
+  )
 
-  const getUserLocation = () => {
+  const getUserLocation = useCallback(() => {
     if ('geolocation' in navigator) {
       setIsLoading(true)
       navigator.geolocation.getCurrentPosition(successFunction, errorFunction, {
-        enableHighAccuracy: false, // Changed to false for compatibility
-        timeout: 150000, // Increased to 15 seconds
+        enableHighAccuracy: false,
+        timeout: 15000,
         maximumAge: 300000 // 5 minutes
       })
     } else {
-      toast.error(tContact('geoLocationPermissionDeniedButtonDescription'), {
+      toast.error(tFindUs('geoLocationPermissionDeniedButtonDescription'), {
         action: {
           label: tCommon('close'),
           onClick: () => toast.dismiss()
@@ -93,26 +96,26 @@ export const ItineraryAlertDialog = () => {
         duration: Infinity
       })
     }
-  }
+  }, [successFunction, errorFunction, tCommon, tFindUs])
 
-  // Watch for changes in geolocation permission
+  // Relaunch the geolocation if the user grants the permission while the dialog is open
   useEffect(() => {
-    const checkPermission = () => {
-      if ('permissions' in navigator) {
-        navigator.permissions
-          .query({ name: 'geolocation' })
-          .then(permissionStatus => {
-            permissionStatus.onchange = () => {
-              if (permissionStatus.state === 'granted' && isDialogOpen) {
-                // Relaunch the geolocation if the user just authorized the permission
-                getUserLocation()
-              }
-            }
-          })
-      }
-    }
+    if (!('permissions' in navigator)) return
 
-    checkPermission()
+    let status: PermissionStatus | undefined
+
+    navigator.permissions.query({ name: 'geolocation' }).then(result => {
+      status = result
+      result.onchange = () => {
+        if (result.state === 'granted' && isDialogOpen) {
+          getUserLocation()
+        }
+      }
+    })
+
+    return () => {
+      if (status) status.onchange = null
+    }
   }, [isDialogOpen, getUserLocation])
 
   // Relaunch the geolocation when the dialog opens
@@ -134,15 +137,17 @@ export const ItineraryAlertDialog = () => {
         <AlertDialogHeader>
           <AlertDialogTitle>
             {isLoading
-              ? tContact('geoLocationLoading')
+              ? tFindUs('geoLocationLoading')
               : !userLocation.length
-                ? tContact('geoLocationNotFound')
-                : tContact('geoLocationFound')}
+                ? tFindUs('geoLocationNotFound')
+                : tFindUs('geoLocationFound')}
           </AlertDialogTitle>
           <AlertDialogDescription>
             {isLoading
-              ? tContact('geoLocationPermissionDeniedDescription')
-              : tContact('confirmLocationDescription')}
+              ? tFindUs('geoLocationPermissionDeniedDescription')
+              : userLocation.length
+                ? tFindUs('locationFoundDescription')
+                : tFindUs('confirmLocationDescription')}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
@@ -154,7 +159,7 @@ export const ItineraryAlertDialog = () => {
                 target='_blank'
                 rel='noopener noreferrer'
               >
-                {tContact('confirmLocationButton')}
+                {tFindUs('confirmLocationButton')}
               </Link>
             </AlertDialogAction>
           )}

--- a/src/shared/components/map/Map.tsx
+++ b/src/shared/components/map/Map.tsx
@@ -10,7 +10,7 @@ import { CustomMarker } from './CustomMaker/CustomMaker'
 import { ItineraryAlertDialog } from './CustomMaker/ItineraryAlertDialog'
 
 export const Map = () => {
-  const t = useTranslations('Contact')
+  const t = useTranslations('FindUs')
 
   return (
     <div className='relative flex h-96 w-full grow flex-col items-center justify-center'>

--- a/src/shared/components/map/MapSection.tsx
+++ b/src/shared/components/map/MapSection.tsx
@@ -14,7 +14,7 @@ const MapWithNoSSR = dynamic(
 )
 
 export const MapSection = () => {
-  const t = useTranslations('Contact')
+  const t = useTranslations('FindUs')
 
   return (
     <section className='flex w-full flex-col gap-4 lg:mb-0'>

--- a/src/shared/components/navbar/DesktopNavbar/DesktopNavbarContent.tsx
+++ b/src/shared/components/navbar/DesktopNavbar/DesktopNavbarContent.tsx
@@ -76,10 +76,10 @@ export const DesktopNavbarContent = () => {
           </NavigationMenuItem>
           <NavigationMenuItem>
             <CustomLink
-              href={navLinks.contact.url}
-              isActive={pathName === navLinks.contact.url}
+              href={navLinks.findUs.url}
+              isActive={pathName === navLinks.findUs.url}
             >
-              {navLinks.contact.label}
+              {navLinks.findUs.label}
             </CustomLink>
           </NavigationMenuItem>
         </NavigationMenuList>

--- a/src/shared/components/navbar/MobileNavbar.tsx
+++ b/src/shared/components/navbar/MobileNavbar.tsx
@@ -146,16 +146,16 @@ export const MobileNavbar = ({
             {navLinks.activities.label}
           </Link>
           <Link
-            href={navLinks.contact.url}
+            href={navLinks.findUs.url}
             onClick={handleCloseNavbar}
             className={cn(
               'flex w-full items-center p-2 rounded text-lg font-semibold',
               {
-                'bg-accent': pathName === navLinks.contact.url
+                'bg-accent': pathName === navLinks.findUs.url
               }
             )}
           >
-            {navLinks.contact.label}
+            {navLinks.findUs.label}
           </Link>
         </main>
 

--- a/src/shared/components/navbar/hook.tsx
+++ b/src/shared/components/navbar/hook.tsx
@@ -23,7 +23,7 @@ export type NavigationLinks = {
   yurt: NavigationLinkWithUrl
   cabin: NavigationLinkWithUrl
   activities: NavigationLinkWithUrl
-  contact: NavigationLinkWithUrl
+  findUs: NavigationLinkWithUrl
 }
 
 export const useGetNavigationLinks = (): NavigationLinks => {
@@ -52,10 +52,10 @@ export const useGetNavigationLinks = (): NavigationLinks => {
       description: null,
       url: PAGE_ROUTES.activity.home
     },
-    contact: {
-      label: tCommon('contact'),
+    findUs: {
+      label: tCommon('findUs'),
       description: null,
-      url: PAGE_ROUTES.contact
+      url: PAGE_ROUTES.findUs
     }
   }
 }


### PR DESCRIPTION
The contact page had no contact form: it shows opening hours, a map, and directions. Rename everything accordingly:

- Route: /contact -> /nous-trouver (fr) and /find-us (en), localized pathnames in routing.ts, sitemap and hreflang/OG URLs updated (old /contact URLs now 404, no redirect kept on purpose)
- i18n: Contact namespace -> FindUs, Common/Footer/SEO keys renamed, nav and footer labels are now "Nous trouver" / "Find us"
- Components: ContactSection -> FindUsSection, admin tab labels now translated through Common keys

Audit fixes on the renamed surface:
- Translate hardcoded (and wrong) opening-hours toasts
- Itinerary dialog: proper description per state, 15s geolocation timeout, memoized callbacks and permission listener cleanup
- Opening hours table: day column header, th scopes, aria-labels on time inputs; valid button content in the popup trigger
- LocalBusiness JSON-LD enriched with telephone and geo

Tooling and tests:
- ESLint migrated to the Next 16 flat config (next lint was removed), lint script now runs eslint .
- AppCarousel: fix react-hooks/set-state-in-effect errors, includes the lazy-mounted lightbox
- map.spec aligned with the current popup (scoped nav selectors, granted geolocation, removed tests for UI that no longer exists); carousel fullscreen assertion skipped where the API is unavailable